### PR TITLE
Get logger from function kwargs

### DIFF
--- a/logdecorator/decorator.py
+++ b/logdecorator/decorator.py
@@ -28,7 +28,12 @@ class LoggingDecorator(DecoratorMixin):
     def log(logger, log_level, msg):
         logger.log(log_level, msg)
 
-    def get_logger(self, fn):
+    def get_logger(self, fn, **kwargs):
+        if isinstance(self._logger, str):
+            if self._logger not in kwargs:
+                raise ValueError(f"Unable to find keyword '{self._logger}'"
+                                  " in function arguments for logger.")
+            self._logger = kwargs.get(self._logger, None)
         if self._logger is None:
             self._logger = logging.getLogger(fn.__module__)
 
@@ -45,7 +50,7 @@ class LoggingDecorator(DecoratorMixin):
 class log_on_start(LoggingDecorator):
 
     def _do_logging(self, fn, *args, **kwargs):
-        logger = self.get_logger(fn)
+        logger = self.get_logger(fn, **kwargs)
         extensive_kwargs = self.build_extensive_kwargs(fn, *args, **kwargs)
         msg = self.message.format(**extensive_kwargs)
 
@@ -64,7 +69,7 @@ class log_on_end(LoggingDecorator):
         self.result_format_variable = result_format_variable
 
     def _do_logging(self, fn, result, *args, **kwargs):
-        logger = self.get_logger(fn)
+        logger = self.get_logger(fn, **kwargs)
         extensive_kwargs = self.build_extensive_kwargs(fn, *args, **kwargs)
         extensive_kwargs[self.result_format_variable] = result
         msg = self.message.format(**extensive_kwargs)
@@ -89,7 +94,7 @@ class log_on_error(LoggingDecorator):
         self.exception_format_variable = exception_format_variable
 
     def _do_logging(self, fn, exception, *args, **kwargs):
-        logger = self.get_logger(fn)
+        logger = self.get_logger(fn, **kwargs)
         extensive_kwargs = self.build_extensive_kwargs(fn, *args, **kwargs)
         extensive_kwargs[self.exception_format_variable] = exception
         msg = self.message.format(**extensive_kwargs)

--- a/logdecorator/tests/tests_generic.py
+++ b/logdecorator/tests/tests_generic.py
@@ -182,3 +182,16 @@ class TestDecorators(TestCase):
         fn = dec(async_test_func)
         self.loop.run_until_complete(fn(2, "asd"))
         self.assertEqual(self.logger.exception.call_count, 1)
+
+    def test_logger_from_function_args(self):
+        kwlogger = logging.Logger('kwarg_logger')
+        kwlog_handler = MockLoggingHandler()
+        kwlog_handler.setFormatter("%(msg)s")
+        kwlogger.addHandler(kwlog_handler)
+        
+        dec = log_on_start(logging.INFO,
+                           "test message {arg1:d}, {arg2:d}",
+                           logger='kwarg1')
+        fn = dec(test_func)
+        fn(1, 2, kwarg1=kwlogger)
+        self.assertIn("test message 1, 2", kwlog_handler.messages["info"])


### PR DESCRIPTION
## Summary

A limitation of Python decorators is that their arguments must be specified during the initial parsing, not during runtime. This means that decorating a class method cannot incorporate a class member as its logger, or a function to use a logger passed as a parameter.

This change allows the `logger` keyword argument in the decorator to accept a string. If `logger` is a string, then it will attempt to find a keyword argument in the function it is decorating with the same name. If no keyword argument exists, a ValueError is raised.

## Added

- Decorator's `logger` argument can take a string to get a keyword argument
- Tests for logger from kwargs